### PR TITLE
Fix backticks in initial database setup

### DIFF
--- a/LinuxSetup.md
+++ b/LinuxSetup.md
@@ -156,7 +156,7 @@ Initial configurations and entries in the database need to be set up to use the 
 2. `use zeppelin;`
 3. `INSERT INTO allowed_guilds (id, name, icon, owner_id) VALUES ("SERVER_ID", "SERVER_NAME", null, "OWNER_ID");`
     - Modify SERVER_ID, SERVER_NAME, OWNER_ID
-4. `INSERT INTO configs (id, `key`, config, is_active, edited_by) VALUES (1, "global", "{\"prefix\": \"!\", \"url\": \"http://localhost:8800\" ,\"owners\": [\"YOUR_ID\"]}", true, "YOUR_ID");`
+4. ``INSERT INTO configs (id, `key`, config, is_active, edited_by) VALUES (1, "global", "{\"prefix\": \"!\", \"url\": \"http://localhost:8800\" ,\"owners\": [\"YOUR_ID\"]}", true, "YOUR_ID");``
     - Modify YOUR_ID X2; replace localhost with domain|ip as applicable
 5. `INSERT INTO configs (id, `key`, config, is_active, edited_by) VALUES (2, "guild-GUILD_ID", "{\"prefix\": \"!\", \"levels\": {\"YOUR_ID\": 100}, \"plugins\": { \"utility\": {}}}", true, "YOUR_ID");`
     - Modify GUILD_ID, YOUR_ID X2


### PR DESCRIPTION
The backticks in the MariaDB initial setup were being formatted as markdown. I fixed it by adding two backticks to the enclosing code block.